### PR TITLE
デプロイ用GHAの権限エラー対応（+ スタイル微修正）

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -14,6 +14,9 @@ jobs:
     needs: check
     runs-on: ubuntu-22.04
     timeout-minutes: 5
+    permissions:
+      # gh-pages ブランチへの書き込み用
+      contents: write
 
     steps:
       - name: Checkout

--- a/css/style.css
+++ b/css/style.css
@@ -120,7 +120,7 @@ a {
 
 .blog-card__footer {
   display: flex;
-  align-items: end;
+  align-items: flex-end;
   height: 40px;
   padding: 0 16px;
   margin-top: 20px;


### PR DESCRIPTION
## Issue 番号
<!-- ※マージとともクローズの場合は closes をつける -->
#7 

## 対応内容
- デプロイ用 GHA での GITHUB_TOKEN に書き込み権限を付与した
- 著者名の下寄せを flex-end に変えてみた